### PR TITLE
Dummy service data

### DIFF
--- a/edr_data_interface/dummy/__init__.py
+++ b/edr_data_interface/dummy/__init__.py
@@ -1,2 +1,3 @@
 from .admin import RefreshCollections
 from .capabilities import API, Capabilities, Conformance
+from .service import Service

--- a/edr_data_interface/dummy/service.py
+++ b/edr_data_interface/dummy/service.py
@@ -1,0 +1,13 @@
+from edr_server.abstract_data_interface.service import Service, ServiceData
+
+
+URLS = {
+    "description_url": "https://www.example.org/service/description.html",
+    "license_url": "https://www.example.org/service/licence.html",
+    "terms_url": "https://www.example.org/service/terms-and-conditions.html",
+}
+
+
+class Service(Service):
+    def data(self) -> ServiceData:
+        return ServiceData(**URLS)


### PR DESCRIPTION
Add an example of specifying URLs as data for EDR service requests. Relates to https://github.com/ADAQ-AQI/edr-server/pull/10.