### PR TITLE
Example locations request handling

### DIFF
--- a/edr_data_interface/dummy/__init__.py
+++ b/edr_data_interface/dummy/__init__.py
@@ -1,4 +1,4 @@
 from .admin import RefreshCollections
 from .capabilities import API, Capabilities, Conformance
-from .locations import Locations
+from .locations import Location, Locations
 from .service import Service


### PR DESCRIPTION
Extend the `dummy` interface with an example of returning data relevant to a `locations` request. See also https://github.com/ADAQ-AQI/edr-server/pull/12.